### PR TITLE
add pyexcel to list

### DIFF
--- a/content/pages/index.md
+++ b/content/pages/index.md
@@ -15,6 +15,12 @@ The recommended package for reading and writing Excel 2010 files (ie: .xlsx)
 
 [Download](http://pypi.python.org/pypi/openpyxl) | [Documentation](https://openpyxl.readthedocs.org/) | [Bitbucket](https://bitbucket.org/openpyxl/openpyxl)
 
+### pyexcel
+
+Library with a unified api for reading and writing files with older Excel files (xls),  Excel 2010 files (xlsx), Open Spreadsheet files (ods), and many other data formats. 
+
+[Download](https://pypi.org/project/pyexcel/) | [Documentation](https://docs.pyexcel.org/en/latest/) | [Bitbucket](https://github.com/pyexcel/pyexcel)
+
 ### xlsxwriter
 
 An alternative package for writing data, formatting information and, in particular, charts in the Excel 2010 format (ie: .xlsx)

--- a/content/pages/index.md
+++ b/content/pages/index.md
@@ -17,7 +17,7 @@ The recommended package for reading and writing Excel 2010 files (ie: .xlsx)
 
 ### pyexcel
 
-Library with a unified api for reading and writing files with older Excel files (xls),  Excel 2010 files (xlsx), Open Spreadsheet files (ods), and many other data formats. 
+Library with a unified api for reading and writing files with older Excel format (xls), Excel 2010 format (xlsx), OpenDocument Spreadsheet format (ods), and many others. 
 
 [Download](https://pypi.org/project/pyexcel/) | [Documentation](https://docs.pyexcel.org/en/latest/) | [Bitbucket](https://github.com/pyexcel/pyexcel)
 


### PR DESCRIPTION
pyexcel is a library that has a unified api for both xlsx and xls and supports many other spreadsheet and data formats. It is actively developed and maintained and a good choice for someone that needs to work with more than 1 spreadsheet type. 

This PR adds it to the list under openpyxl which, in my opinion, is still the standard for working with Excel 2010 files in 2023. 