### PR TITLE
Remove PLUGINS from pelicanconf.py

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -39,10 +39,6 @@ STATIC_PATHS = [
     'extra'
 ]
 
-PLUGINS = [
-    'pelican_webassets'
-]
-
 EXTRA_PATH_METADATA = {
     'extra/CNAME': {'path': 'CNAME'}
 }


### PR DESCRIPTION
The pelican-webassets plugin is now configured automatically and explicitly listing it as a plugin causes the build to fail.