### PR TITLE
add pyexcel to list

### DIFF
--- a/content/pages/index.md
+++ b/content/pages/index.md
@@ -21,6 +21,12 @@ An alternative package for writing data, formatting information and, in particul
 
 [Download](https://pypi.python.org/pypi/XlsxWriter) | [Documentation](https://xlsxwriter.readthedocs.org/) | [GitHub](https://github.com/jmcnamara/XlsxWriter)
 
+### pyexcel
+
+Library with a unified api for reading and writing files with older Excel format (xls), Excel 2010 format (xlsx), OpenDocument Spreadsheet format (ods), and many others.
+
+[Download](https://pypi.org/project/pyexcel/) | [Documentation](https://docs.pyexcel.org/en/latest/) | [Bitbucket](https://github.com/pyexcel/pyexcel)
+
 ### pyxlsb
 
 This package allows you to read Excel files in the `xlsb` format.


### PR DESCRIPTION
Clone of PR #6  from [Djones4822](https://github.com/Djones4822)

pyexcel is a library that has a unified api for both xlsx and xls and supports many other spreadsheet and data formats. It is actively developed and maintained and a good choice for someone that needs to work with more than 1 spreadsheet type.

This PR adds it to the list under openpyxl which, in my opinion, is still the standard for working with Excel 2010 files in 2023.